### PR TITLE
LABS-24: Remove Now from Index bindings

### DIFF
--- a/src/fauna/queries/fweets.js
+++ b/src/fauna/queries/fweets.js
@@ -108,7 +108,8 @@ function LikeFweet(fweetRef) {
             fweet: fweetRef,
             like: Var('newLikeStatus'),
             refweet: false,
-            comment: false
+            comment: false,
+            created: Now()
           }
         })
       ),
@@ -170,7 +171,8 @@ function Refweet(fweetRef, message, tags) {
                 fweet: fweetRef,
                 like: false,
                 refweet: true,
-                comment: false
+                comment: false,
+                created: Now()
               }
             })
           ),
@@ -235,7 +237,8 @@ function Comment(fweetRef, message) {
             fweet: fweetRef,
             like: false,
             refweet: false,
-            comment: true
+            comment: true,
+            created: Now()
           }
         })
       ),

--- a/src/fauna/setup/followerstats.js
+++ b/src/fauna/setup/followerstats.js
@@ -72,7 +72,7 @@ const CreateIndexByUserPopularity = CreateIndex({
                 refweetsfactor: 1,
                 postlikes: Select(['data', 'postlikes'], Var('stats')),
                 postrefweets: Select(['data', 'postrefweets'], Var('stats')),
-                txtime: Now(),
+                txtime: Select(['data', 'created'], Var('stats')),
                 unixstarttime: Time('1970-01-01T00:00:00+00:00'),
                 ageInSecsSinceUnix: TimeDiff(Var('unixstarttime'), Var('txtime'), 'minutes')
               },

--- a/src/fauna/setup/fweets.js
+++ b/src/fauna/setup/fweets.js
@@ -135,15 +135,7 @@ const CreateIndexFweetsByTag = CreateIndex({
               likes: Select(['data', 'likes'], Var('fweet')),
               comments: Select(['data', 'comments'], Var('fweet')),
               refweets: Select(['data', 'refweets'], Var('fweet')),
-
-              // DISCLAIMER !!!!
-              // Now() should not be used in bindings since it does not provide correct results,
-              // Something I did not know at the time of writing.
-              // Instead please use either a created_at time you store on the document 
-              // or an updated time instead. We'll update the app from the moment I find time to test
-              // an alternative approach. 
-
-              txtime: Now(),
+              txtime: Select(['data', 'created'], Var('fweet')),
               unixstarttime: Time('1970-01-01T00:00:00+00:00'),
               ageInSecsSinceUnix: TimeDiff(Var('unixstarttime'), Var('txtime'), 'minutes')
             },


### PR DESCRIPTION
Addresses #74 

Removed `Now` from `fweets_by_tag` and `followerstats_by_user_popularity` indexes.  Also adds `created` fields for all places fweetstats are created.

