### PR TITLE
Fixed order of arguments in If Statements

### DIFF
--- a/src/fauna/setup/accounts.js
+++ b/src/fauna/setup/accounts.js
@@ -51,9 +51,9 @@ async function createAccountCollection(client) {
 }
 
 async function deleteAccountsCollection(client) {
-  await client.query(If(Exists(Collection('accounts')), true, Delete(Collection('accounts'))))
-  await client.query(If(Exists(Index('accounts_by_email')), true, Delete(Index('accounts_by_email'))))
-  await client.query(If(Exists(Index('all_accounts')), true, Delete(Delete('all_accounts'))))
+  await client.query(If(Exists(Collection('accounts')), Delete(Collection('accounts')), true))
+  await client.query(If(Exists(Index('accounts_by_email')), Delete(Index('accounts_by_email')), true))
+  await client.query(If(Exists(Index('all_accounts')), Delete(Delete('all_accounts')), true))
 }
 
 const DeleteAllAccounts = If(

--- a/src/fauna/setup/comments.js
+++ b/src/fauna/setup/comments.js
@@ -39,8 +39,8 @@ async function createCommentsCollection(client) {
 // If you delete a collection/index you have to wait 60 secs before the
 // names go out of the cache before you reuse them.
 async function deleteCommentsCollection(client) {
-  await client.query(If(Exists(Collection('comments')), Delete(Collection('comments')), true))
-  await client.query(If(Exists(Index('comments_by_fweet_ordered')), Delete(Index('comments_by_fweet_ordered')), true))
+  await client.query(If(Exists(Collection('comments')), true, Delete(Collection('comments'))))
+  await client.query(If(Exists(Index('comments_by_fweet_ordered')), true, Delete(Index('comments_by_fweet_ordered'))))
 }
 
 // Example of how you could delete all comments in a collection

--- a/src/fauna/setup/comments.js
+++ b/src/fauna/setup/comments.js
@@ -39,8 +39,8 @@ async function createCommentsCollection(client) {
 // If you delete a collection/index you have to wait 60 secs before the
 // names go out of the cache before you reuse them.
 async function deleteCommentsCollection(client) {
-  await client.query(If(Exists(Collection('comments')), true, Delete(Collection('comments'))))
-  await client.query(If(Exists(Index('comments_by_fweet_ordered')), true, Delete(Index('comments_by_fweet_ordered'))))
+  await client.query(If(Exists(Collection('comments')), Delete(Collection('comments')), true))
+  await client.query(If(Exists(Index('comments_by_fweet_ordered')), Delete(Index('comments_by_fweet_ordered')), true))
 }
 
 // Example of how you could delete all comments in a collection

--- a/src/fauna/setup/followerstats.js
+++ b/src/fauna/setup/followerstats.js
@@ -117,16 +117,16 @@ async function createFollowerStatsCollection(client) {
 }
 
 async function deleteFollowerStatsCollection(client) {
-  await client.query(If(Exists(Collection('followerstats')), Delete(Collection('followerstats')),true))
+  await client.query(If(Exists(Collection('followerstats')), true, Delete(Collection('followerstats'))))
   await client.query(
     If(
       Exists(Index('followerstats_by_author_and_follower')),
-      Delete(Index('followerstats_by_author_and_follower')),
-        true
+      true,
+      Delete(Index('followerstats_by_author_and_follower'))
     )
   )
   await client.query(
-    If(Exists(Index('followerstats_by_user_popularity')),  Delete(Index('followerstats_by_user_popularity')),true)
+    If(Exists(Index('followerstats_by_user_popularity')), true, Delete(Index('followerstats_by_user_popularity')))
   )
 }
 

--- a/src/fauna/setup/followerstats.js
+++ b/src/fauna/setup/followerstats.js
@@ -117,16 +117,16 @@ async function createFollowerStatsCollection(client) {
 }
 
 async function deleteFollowerStatsCollection(client) {
-  await client.query(If(Exists(Collection('followerstats')), true, Delete(Collection('followerstats'))))
+  await client.query(If(Exists(Collection('followerstats')), Delete(Collection('followerstats')),true))
   await client.query(
     If(
       Exists(Index('followerstats_by_author_and_follower')),
-      true,
-      Delete(Index('followerstats_by_author_and_follower'))
+      Delete(Index('followerstats_by_author_and_follower')),
+        true
     )
   )
   await client.query(
-    If(Exists(Index('followerstats_by_user_popularity')), true, Delete(Index('followerstats_by_user_popularity')))
+    If(Exists(Index('followerstats_by_user_popularity')),  Delete(Index('followerstats_by_user_popularity')),true)
   )
 }
 

--- a/src/fauna/setup/followerstats.js
+++ b/src/fauna/setup/followerstats.js
@@ -117,16 +117,16 @@ async function createFollowerStatsCollection(client) {
 }
 
 async function deleteFollowerStatsCollection(client) {
-  await client.query(If(Exists(Collection('followerstats')), true, Delete(Collection('followerstats'))))
+  await client.query(If(Exists(Collection('followerstats')), Delete(Collection('followerstats')), true))
   await client.query(
     If(
       Exists(Index('followerstats_by_author_and_follower')),
-      true,
-      Delete(Index('followerstats_by_author_and_follower'))
+      Delete(Index('followerstats_by_author_and_follower')),
+        true
     )
   )
   await client.query(
-    If(Exists(Index('followerstats_by_user_popularity')), true, Delete(Index('followerstats_by_user_popularity')))
+    If(Exists(Index('followerstats_by_user_popularity')), Delete(Index('followerstats_by_user_popularity')), true)
   )
 }
 

--- a/src/fauna/setup/fweets.js
+++ b/src/fauna/setup/fweets.js
@@ -199,19 +199,18 @@ async function createFweetsCollection(client) {
 // If you delete a collection/index you have to wait 60 secs before the
 // names go out of the cache before you reuse them.
 async function deleteFweetsCollection(client) {
-  await client.query(If(Exists(Collection('fweets')), true, Delete(Collection('fweets'))))
-  await client.query(If(Exists(Index('all_fweets')), true, Delete(Index('all_fweets'))))
-  await client.query(If(Exists(Index('fweets_by_author')), true, Delete(Index('fweets_by_author'))))
-  await client.query(If(Exists(Index('fweets_by_tag')), true, Delete(Index('fweets_by_tag'))))
-  await client.query(If(Exists(Index('fweets_by_reference')), true, Delete(Index('fweets_by_reference'))))
-  await client.query(If(Exists(Index('fweets_by_hashtag_ref')), true, Delete(Index('fweets_by_hashtag_ref'))))
+  await client.query(If(Exists(Collection('fweets')), Delete(Collection('fweets')),true))
+  await client.query(If(Exists(Index('all_fweets')), Delete(Index('all_fweets')),true))
+  await client.query(If(Exists(Index('fweets_by_author')),  Delete(Index('fweets_by_author')),true))
+  await client.query(If(Exists(Index('fweets_by_tag')),  Delete(Index('fweets_by_tag')),true))
+  await client.query(If(Exists(Index('fweets_by_reference')), Delete(Index('fweets_by_reference')),true))
+  await client.query(If(Exists(Index('fweets_by_hashtag_ref')),  Delete(Index('fweets_by_hashtag_ref')),true))
 }
 
 // Example of how you could delete all fweets in a collection
 const DeleteAllFweets = If(
   Exists(Collection('fweets')),
-  q.Map(Paginate(Documents(Collection('fweets'))), Lambda('ref', Delete(Var('ref')))),
-  true
+  q.Map(Paginate(Documents(Collection('fweets'))), Lambda('ref', Delete(Var('ref')), true))
 )
 
 export { createFweetsCollection, deleteFweetsCollection, DeleteAllFweets }

--- a/src/fauna/setup/fweets.js
+++ b/src/fauna/setup/fweets.js
@@ -199,18 +199,19 @@ async function createFweetsCollection(client) {
 // If you delete a collection/index you have to wait 60 secs before the
 // names go out of the cache before you reuse them.
 async function deleteFweetsCollection(client) {
-  await client.query(If(Exists(Collection('fweets')), Delete(Collection('fweets')),true))
-  await client.query(If(Exists(Index('all_fweets')), Delete(Index('all_fweets')),true))
-  await client.query(If(Exists(Index('fweets_by_author')),  Delete(Index('fweets_by_author')),true))
-  await client.query(If(Exists(Index('fweets_by_tag')),  Delete(Index('fweets_by_tag')),true))
-  await client.query(If(Exists(Index('fweets_by_reference')), Delete(Index('fweets_by_reference')),true))
-  await client.query(If(Exists(Index('fweets_by_hashtag_ref')),  Delete(Index('fweets_by_hashtag_ref')),true))
+  await client.query(If(Exists(Collection('fweets')), true, Delete(Collection('fweets'))))
+  await client.query(If(Exists(Index('all_fweets')), true, Delete(Index('all_fweets'))))
+  await client.query(If(Exists(Index('fweets_by_author')), true, Delete(Index('fweets_by_author'))))
+  await client.query(If(Exists(Index('fweets_by_tag')), true, Delete(Index('fweets_by_tag'))))
+  await client.query(If(Exists(Index('fweets_by_reference')), true, Delete(Index('fweets_by_reference'))))
+  await client.query(If(Exists(Index('fweets_by_hashtag_ref')), true, Delete(Index('fweets_by_hashtag_ref'))))
 }
 
 // Example of how you could delete all fweets in a collection
 const DeleteAllFweets = If(
   Exists(Collection('fweets')),
-  q.Map(Paginate(Documents(Collection('fweets'))), Lambda('ref', Delete(Var('ref')), true))
+  q.Map(Paginate(Documents(Collection('fweets'))), Lambda('ref', Delete(Var('ref')))),
+  true
 )
 
 export { createFweetsCollection, deleteFweetsCollection, DeleteAllFweets }

--- a/src/fauna/setup/fweets.js
+++ b/src/fauna/setup/fweets.js
@@ -199,19 +199,18 @@ async function createFweetsCollection(client) {
 // If you delete a collection/index you have to wait 60 secs before the
 // names go out of the cache before you reuse them.
 async function deleteFweetsCollection(client) {
-  await client.query(If(Exists(Collection('fweets')), true, Delete(Collection('fweets'))))
-  await client.query(If(Exists(Index('all_fweets')), true, Delete(Index('all_fweets'))))
-  await client.query(If(Exists(Index('fweets_by_author')), true, Delete(Index('fweets_by_author'))))
-  await client.query(If(Exists(Index('fweets_by_tag')), true, Delete(Index('fweets_by_tag'))))
-  await client.query(If(Exists(Index('fweets_by_reference')), true, Delete(Index('fweets_by_reference'))))
-  await client.query(If(Exists(Index('fweets_by_hashtag_ref')), true, Delete(Index('fweets_by_hashtag_ref'))))
+  await client.query(If(Exists(Collection('fweets')), Delete(Collection('fweets')), true))
+  await client.query(If(Exists(Index('all_fweets')), Delete(Index('all_fweets')), true))
+  await client.query(If(Exists(Index('fweets_by_author')), Delete(Index('fweets_by_author')), true))
+  await client.query(If(Exists(Index('fweets_by_tag')), Delete(Index('fweets_by_tag')), true))
+  await client.query(If(Exists(Index('fweets_by_reference')), Delete(Index('fweets_by_reference')), true))
+  await client.query(If(Exists(Index('fweets_by_hashtag_ref')), Delete(Index('fweets_by_hashtag_ref')), true))
 }
 
 // Example of how you could delete all fweets in a collection
 const DeleteAllFweets = If(
   Exists(Collection('fweets')),
-  q.Map(Paginate(Documents(Collection('fweets'))), Lambda('ref', Delete(Var('ref')))),
-  true
+  q.Map(Paginate(Documents(Collection('fweets'))), Lambda('ref', Delete(Var('ref')), true))
 )
 
 export { createFweetsCollection, deleteFweetsCollection, DeleteAllFweets }

--- a/src/fauna/setup/fweetstats.js
+++ b/src/fauna/setup/fweetstats.js
@@ -37,16 +37,13 @@ async function createFweetStatsCollection(client) {
 }
 
 async function deleteFweetStatsCollection(client) {
-  await client.query(If(Exists(Collection('fweetstats')), true, Delete(Collection('fweetstats'))))
-  await client.query(
-    If(Exists(Index('fweetstats_by_user_and_fweet')), true, Delete(Index('fweetstats_by_user_and_fweet')))
-  )
+  await client.query(If(Exists(Collection('fweetstats')),  Delete(Collection('fweetstats')),true))
+  await client.query(If(Exists(Index('fweetstats_by_user_and_fweet')),  Delete(Index('fweetstats_by_user_and_fweet')),true))
 }
 
 const DeleteAllFweetStats = If(
   Exists(Collection('fweetstats')),
-  q.Map(Paginate(Documents(Collection('fweetstats'))), Lambda('ref', Delete(Var('ref')))),
-  true
+  q.Map(Paginate(Documents(Collection('fweetstats'))), Lambda('ref', Delete(Var('ref')))), true
 )
 
 export { DeleteAllFweetStats, createFweetStatsCollection, deleteFweetStatsCollection }

--- a/src/fauna/setup/fweetstats.js
+++ b/src/fauna/setup/fweetstats.js
@@ -37,16 +37,13 @@ async function createFweetStatsCollection(client) {
 }
 
 async function deleteFweetStatsCollection(client) {
-  await client.query(If(Exists(Collection('fweetstats')), true, Delete(Collection('fweetstats'))))
-  await client.query(
-    If(Exists(Index('fweetstats_by_user_and_fweet')), true, Delete(Index('fweetstats_by_user_and_fweet')))
-  )
+  await client.query(If(Exists(Collection('fweetstats')), Delete(Collection('fweetstats')), true))
+  await client.query(If(Exists(Index('fweetstats_by_user_and_fweet')), Delete(Index('fweetstats_by_user_and_fweet')), true))
 }
 
 const DeleteAllFweetStats = If(
   Exists(Collection('fweetstats')),
-  q.Map(Paginate(Documents(Collection('fweetstats'))), Lambda('ref', Delete(Var('ref')))),
-  true
+  q.Map(Paginate(Documents(Collection('fweetstats'))), Lambda('ref', Delete(Var('ref')))), true
 )
 
 export { DeleteAllFweetStats, createFweetStatsCollection, deleteFweetStatsCollection }

--- a/src/fauna/setup/fweetstats.js
+++ b/src/fauna/setup/fweetstats.js
@@ -37,13 +37,16 @@ async function createFweetStatsCollection(client) {
 }
 
 async function deleteFweetStatsCollection(client) {
-  await client.query(If(Exists(Collection('fweetstats')),  Delete(Collection('fweetstats')),true))
-  await client.query(If(Exists(Index('fweetstats_by_user_and_fweet')),  Delete(Index('fweetstats_by_user_and_fweet')),true))
+  await client.query(If(Exists(Collection('fweetstats')), true, Delete(Collection('fweetstats'))))
+  await client.query(
+    If(Exists(Index('fweetstats_by_user_and_fweet')), true, Delete(Index('fweetstats_by_user_and_fweet')))
+  )
 }
 
 const DeleteAllFweetStats = If(
   Exists(Collection('fweetstats')),
-  q.Map(Paginate(Documents(Collection('fweetstats'))), Lambda('ref', Delete(Var('ref')))), true
+  q.Map(Paginate(Documents(Collection('fweetstats'))), Lambda('ref', Delete(Var('ref')))),
+  true
 )
 
 export { DeleteAllFweetStats, createFweetStatsCollection, deleteFweetStatsCollection }

--- a/src/fauna/setup/hashtags.js
+++ b/src/fauna/setup/hashtags.js
@@ -31,14 +31,13 @@ async function createHashtagCollection(client) {
 }
 
 async function deleteHashtagCollection(client) {
-  await client.query(If(Exists(Collection('hashtags')), true, Delete(Collection('hashtags'))))
-  await client.query(If(Exists(Index('hashtags_by_name')), true, Delete(Index('hashtags_by_name'))))
+  await client.query(If(Exists(Collection('hashtags')),  Delete(Collection('hashtags')),true))
+  await client.query(If(Exists(Index('hashtags_by_name')),  Delete(Index('hashtags_by_name')),true))
 }
 
 const DeleteAllHashtags = If(
   Exists(Collection('hashtags')),
-  q.Map(Paginate(Documents(Collection('hashtags'))), Lambda('ref', Delete(Var('ref')))),
-  true
+  q.Map(Paginate(Documents(Collection('hashtags'))), Lambda('ref', Delete(Var('ref')))), true
 )
 
 export { createHashtagCollection, deleteHashtagCollection, DeleteAllHashtags }

--- a/src/fauna/setup/hashtags.js
+++ b/src/fauna/setup/hashtags.js
@@ -31,13 +31,14 @@ async function createHashtagCollection(client) {
 }
 
 async function deleteHashtagCollection(client) {
-  await client.query(If(Exists(Collection('hashtags')),  Delete(Collection('hashtags')),true))
-  await client.query(If(Exists(Index('hashtags_by_name')),  Delete(Index('hashtags_by_name')),true))
+  await client.query(If(Exists(Collection('hashtags')), true, Delete(Collection('hashtags'))))
+  await client.query(If(Exists(Index('hashtags_by_name')), true, Delete(Index('hashtags_by_name'))))
 }
 
 const DeleteAllHashtags = If(
   Exists(Collection('hashtags')),
-  q.Map(Paginate(Documents(Collection('hashtags'))), Lambda('ref', Delete(Var('ref')))), true
+  q.Map(Paginate(Documents(Collection('hashtags'))), Lambda('ref', Delete(Var('ref')))),
+  true
 )
 
 export { createHashtagCollection, deleteHashtagCollection, DeleteAllHashtags }

--- a/src/fauna/setup/hashtags.js
+++ b/src/fauna/setup/hashtags.js
@@ -31,14 +31,13 @@ async function createHashtagCollection(client) {
 }
 
 async function deleteHashtagCollection(client) {
-  await client.query(If(Exists(Collection('hashtags')), true, Delete(Collection('hashtags'))))
-  await client.query(If(Exists(Index('hashtags_by_name')), true, Delete(Index('hashtags_by_name'))))
+  await client.query(If(Exists(Collection('hashtags')), Delete(Collection('hashtags')), true))
+  await client.query(If(Exists(Index('hashtags_by_name')), Delete(Index('hashtags_by_name')), true))
 }
 
 const DeleteAllHashtags = If(
   Exists(Collection('hashtags')),
-  q.Map(Paginate(Documents(Collection('hashtags'))), Lambda('ref', Delete(Var('ref')))),
-  true
+  q.Map(Paginate(Documents(Collection('hashtags'))), Lambda('ref', Delete(Var('ref')))), true
 )
 
 export { createHashtagCollection, deleteHashtagCollection, DeleteAllHashtags }

--- a/src/fauna/setup/rate-limiting.js
+++ b/src/fauna/setup/rate-limiting.js
@@ -44,21 +44,20 @@ async function createRateLimitingCollection(client) {
 }
 
 async function deleteRateLimitingCollection(client) {
-  await client.query(If(Exists(Collection('rate_limiting')), true, Delete(Collection('rate_limiting'))))
-  await client.query(If(Exists(Index('all_rate_limiting')), true, Delete(Index('all_rate_limiting'))))
+  await client.query(If(Exists(Collection('rate_limiting')),  Delete(Collection('rate_limiting')),true))
+  await client.query(If(Exists(Index('all_rate_limiting')),  Delete(Index('all_rate_limiting')),true))
   await client.query(
     If(
       Exists(Index('rate_limiting_by_action_and_identity')),
-      true,
-      Delete(Index('rate_limiting_by_action_and_identity'))
+      Delete(Index('rate_limiting_by_action_and_identity')),
+        true
     )
   )
 }
 
 const DeleteAllRatelimiting = If(
   Exists(Collection('rate_limiting')),
-  q.Map(Paginate(Documents(Collection('rate_limiting'))), Lambda('ref', Delete(Var('ref')))),
-  true
+  q.Map(Paginate(Documents(Collection('rate_limiting'))), Lambda('ref', Delete(Var('ref')))), true
 )
 
 export { createRateLimitingCollection, deleteRateLimitingCollection, CreateIndexAllRateLimiting, DeleteAllRatelimiting }

--- a/src/fauna/setup/rate-limiting.js
+++ b/src/fauna/setup/rate-limiting.js
@@ -44,21 +44,20 @@ async function createRateLimitingCollection(client) {
 }
 
 async function deleteRateLimitingCollection(client) {
-  await client.query(If(Exists(Collection('rate_limiting')), true, Delete(Collection('rate_limiting'))))
-  await client.query(If(Exists(Index('all_rate_limiting')), true, Delete(Index('all_rate_limiting'))))
+  await client.query(If(Exists(Collection('rate_limiting')), Delete(Collection('rate_limiting')), true))
+  await client.query(If(Exists(Index('all_rate_limiting')), Delete(Index('all_rate_limiting')), true))
   await client.query(
     If(
       Exists(Index('rate_limiting_by_action_and_identity')),
-      true,
-      Delete(Index('rate_limiting_by_action_and_identity'))
+      Delete(Index('rate_limiting_by_action_and_identity')),
+        true
     )
   )
 }
 
 const DeleteAllRatelimiting = If(
   Exists(Collection('rate_limiting')),
-  q.Map(Paginate(Documents(Collection('rate_limiting'))), Lambda('ref', Delete(Var('ref')))),
-  true
+  q.Map(Paginate(Documents(Collection('rate_limiting'))), Lambda('ref', Delete(Var('ref')))), true
 )
 
 export { createRateLimitingCollection, deleteRateLimitingCollection, CreateIndexAllRateLimiting, DeleteAllRatelimiting }

--- a/src/fauna/setup/rate-limiting.js
+++ b/src/fauna/setup/rate-limiting.js
@@ -44,20 +44,21 @@ async function createRateLimitingCollection(client) {
 }
 
 async function deleteRateLimitingCollection(client) {
-  await client.query(If(Exists(Collection('rate_limiting')),  Delete(Collection('rate_limiting')),true))
-  await client.query(If(Exists(Index('all_rate_limiting')),  Delete(Index('all_rate_limiting')),true))
+  await client.query(If(Exists(Collection('rate_limiting')), true, Delete(Collection('rate_limiting'))))
+  await client.query(If(Exists(Index('all_rate_limiting')), true, Delete(Index('all_rate_limiting'))))
   await client.query(
     If(
       Exists(Index('rate_limiting_by_action_and_identity')),
-      Delete(Index('rate_limiting_by_action_and_identity')),
-        true
+      true,
+      Delete(Index('rate_limiting_by_action_and_identity'))
     )
   )
 }
 
 const DeleteAllRatelimiting = If(
   Exists(Collection('rate_limiting')),
-  q.Map(Paginate(Documents(Collection('rate_limiting'))), Lambda('ref', Delete(Var('ref')))), true
+  q.Map(Paginate(Documents(Collection('rate_limiting'))), Lambda('ref', Delete(Var('ref')))),
+  true
 )
 
 export { createRateLimitingCollection, deleteRateLimitingCollection, CreateIndexAllRateLimiting, DeleteAllRatelimiting }

--- a/src/fauna/setup/searching.js
+++ b/src/fauna/setup/searching.js
@@ -269,7 +269,7 @@ async function createSearchIndexes(client) {
 
 async function deleteSearchIndexes(client) {
   await client.query(
-    If(Exists(Index('hashtags_and_users_by_wordparts')), true, Delete(Index('hashtags_and_users_by_wordparts')))
+    If(Exists(Index('hashtags_and_users_by_wordparts')), Delete(Index('hashtags_and_users_by_wordparts')), true)
   )
 }
 

--- a/src/fauna/setup/searching.js
+++ b/src/fauna/setup/searching.js
@@ -269,7 +269,7 @@ async function createSearchIndexes(client) {
 
 async function deleteSearchIndexes(client) {
   await client.query(
-    If(Exists(Index('hashtags_and_users_by_wordparts')), true, Delete(Index('hashtags_and_users_by_wordparts')))
+    If(Exists(Index('hashtags_and_users_by_wordparts')),  Delete(Index('hashtags_and_users_by_wordparts')),true)
   )
 }
 

--- a/src/fauna/setup/searching.js
+++ b/src/fauna/setup/searching.js
@@ -269,7 +269,7 @@ async function createSearchIndexes(client) {
 
 async function deleteSearchIndexes(client) {
   await client.query(
-    If(Exists(Index('hashtags_and_users_by_wordparts')),  Delete(Index('hashtags_and_users_by_wordparts')),true)
+    If(Exists(Index('hashtags_and_users_by_wordparts')), true, Delete(Index('hashtags_and_users_by_wordparts')))
   )
 }
 

--- a/src/fauna/setup/users.js
+++ b/src/fauna/setup/users.js
@@ -54,15 +54,15 @@ async function createUsersCollection(client) {
 
 async function deleteUsersCollection(client) {
   await handlePromiseError(
-    client.query(If(Exists(Collection('users')), true, Delete(Collection('users')))),
+    client.query(If(Exists(Collection('users')),  Delete(Collection('users')),true)),
     'Delete users collection'
   )
   await handlePromiseError(
-    client.query(If(Exists(Index('users_by_alias')), true, Delete(Index('users_by_alias')))),
+    client.query(If(Exists(Index('users_by_alias')),  Delete(Index('users_by_alias')),true)),
     'Delete users_by_alias index'
   )
   await handlePromiseError(
-    client.query(If(Exists(Index('all_users')), true, Delete(Index('all_users')))),
+    client.query(If(Exists(Index('all_users')),  Delete(Index('all_users')),true)),
     'Delete all_users index'
   )
 }

--- a/src/fauna/setup/users.js
+++ b/src/fauna/setup/users.js
@@ -54,15 +54,15 @@ async function createUsersCollection(client) {
 
 async function deleteUsersCollection(client) {
   await handlePromiseError(
-    client.query(If(Exists(Collection('users')), true, Delete(Collection('users')))),
+    client.query(If(Exists(Collection('users')), Delete(Collection('users')), true)),
     'Delete users collection'
   )
   await handlePromiseError(
-    client.query(If(Exists(Index('users_by_alias')), true, Delete(Index('users_by_alias')))),
+    client.query(If(Exists(Index('users_by_alias')), Delete(Index('users_by_alias')), true)),
     'Delete users_by_alias index'
   )
   await handlePromiseError(
-    client.query(If(Exists(Index('all_users')), true, Delete(Index('all_users')))),
+    client.query(If(Exists(Index('all_users')), Delete(Index('all_users')), true)),
     'Delete all_users index'
   )
 }

--- a/src/fauna/setup/users.js
+++ b/src/fauna/setup/users.js
@@ -54,15 +54,15 @@ async function createUsersCollection(client) {
 
 async function deleteUsersCollection(client) {
   await handlePromiseError(
-    client.query(If(Exists(Collection('users')),  Delete(Collection('users')),true)),
+    client.query(If(Exists(Collection('users')), true, Delete(Collection('users')))),
     'Delete users collection'
   )
   await handlePromiseError(
-    client.query(If(Exists(Index('users_by_alias')),  Delete(Index('users_by_alias')),true)),
+    client.query(If(Exists(Index('users_by_alias')), true, Delete(Index('users_by_alias')))),
     'Delete users_by_alias index'
   )
   await handlePromiseError(
-    client.query(If(Exists(Index('all_users')),  Delete(Index('all_users')),true)),
+    client.query(If(Exists(Index('all_users')), true, Delete(Index('all_users')))),
     'Delete all_users index'
   )
 }


### PR DESCRIPTION
### Current Issue
The IF statements on a few files seem to have the arguments in the wrong order and I've only made the change in the setup/accounts.js file to confirm that I've understood it correctly before running with the changes to the rest of the files.

### Proposed Fix
As I understand it, the If statement works as follows:
If(_condition_, _true_, _false_)

In that case, when we are deleting a collection or index, we're checking if it exists so:
```
// In PseudoCode
If(Collection Exists, Delete it, Otherwise return true)

// Or, in FQL
If(Exists(Collection('accounts')), Delete(Collection('accounts')), true)
```

### Other Comments
The way it's currently stated in the files, nothing will be deleted since when the collection or index exists, it simply returns true.